### PR TITLE
Специальный синтаксис событий и генерация событий функциями

### DIFF
--- a/__mocks__/event-emitter.js
+++ b/__mocks__/event-emitter.js
@@ -1,0 +1,16 @@
+export default class EventEmitter {
+  listeners = {};
+  emit(event, ...args) {
+    if (this.listeners[event]) {
+      this.listeners[event].forEach(listener => {
+        listener(...args)
+      })
+    }
+  }
+  on(event, listener) {
+    if (!this.listeners[event]) {
+      this.listeners[event] = []
+    }
+    this.listeners[event].push(listener)
+  }
+}

--- a/__tests__/events.test.js
+++ b/__tests__/events.test.js
@@ -1,0 +1,9 @@
+import { init, prepare, start, build, generator } from '../events'
+
+describe('events', () => {
+  it('should format', () => {
+    expect(init(build)).toBe('init:build')
+    expect(prepare(generator)).toBe('prepare:generator')
+    expect(start(generator)).toBe('start:generator')
+  })
+})

--- a/events.js
+++ b/events.js
@@ -1,0 +1,6 @@
+export const init = command => `init:${command()}`
+export const prepare = command => `prepare:${command()}`
+export const start = command => `start:${command()}`
+
+export const build = () => 'build'
+export const generator = () => 'generator'

--- a/index.js
+++ b/index.js
@@ -2,4 +2,6 @@ const getBabelrcConfig = require('./babel.js')
 
 require('babel-register')(getBabelrcConfig())
 
-module.exports = require('./init')
+const { default: init } = require('./init')
+
+module.exports = init

--- a/plopfile.js
+++ b/plopfile.js
@@ -1,9 +1,11 @@
+import { generator as generatorEvent } from './events'
+
 const path = require('path')
 const fs = require('fs')
 const core = require('./index')
 
 module.exports = plop => {
-  core('generator', plop)
+  core(generatorEvent(), plop)
 
   const featureList =
     fs.readdirSync('../')


### PR DESCRIPTION
Для улучшения понятности зависимостей между модулями и уменьшения хаоса событий необходимо привести активаторы к следующему виду

```
import { init } from '@rispa/core/events'

const activator = on => {
  on(init(build), handleInit)
}
```

`build` в данном контексте это `const build = () => 'build'` `init` аналогично только 
```
init = command => `init:${command()}`
```

Следовательно все модули получат явные зависимости от необходимых зависимостей

https://trello.com/c/CyUZyW3d

**BREAKING CHANGE**:
Убрал первый аргумент (command) из функции, передаваемой в on.

- [x] Нужно обновить плагины